### PR TITLE
Silence E501 (Flake8 line length) in tests

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -62,7 +62,7 @@ class TestSolrSession:
             (
                 True,
                 None,
-                "id,title,author_raw,publishYear,created_date,material_type,call_number,isbn,language,eprovider,econtrolnumber,eurl,digital_avail_type,digital_copies_owned",
+                "id,title,author_raw,publishYear,created_date,material_type,call_number,isbn,language,eprovider,econtrolnumber,eurl,digital_avail_type,digital_copies_owned",  # noqa: E501
             ),
             (
                 False,
@@ -390,7 +390,7 @@ class TestSolrSessionLiveService:
             assert response.status_code == 200
             assert (
                 response.url
-                == "https://www.bklynlibrary.org/solr/api/select/?rows=2&fq=material_type%3ABook&q=title%3Acivil+AND+war"
+                == "https://www.bklynlibrary.org/solr/api/select/?rows=2&fq=material_type%3ABook&q=title%3Acivil+AND+war"  # noqa: E501
             )
 
     def test_search_bibNo(self, live_key):
@@ -403,7 +403,7 @@ class TestSolrSessionLiveService:
             assert response.status_code == 200
             assert (
                 response.url
-                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=id%3A10000017&fl=id%2Ctitle%2Cauthor_raw%2CpublishYear%2Ccreated_date%2Cmaterial_type%2Ccall_number%2Cisbn%2Clanguage%2Ceprovider%2Cecontrolnumber%2Ceurl%2Cdigital_avail_type%2Cdigital_copies_owned"
+                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=id%3A10000017&fl=id%2Ctitle%2Cauthor_raw%2CpublishYear%2Ccreated_date%2Cmaterial_type%2Ccall_number%2Cisbn%2Clanguage%2Ceprovider%2Cecontrolnumber%2Ceurl%2Cdigital_avail_type%2Cdigital_copies_owned"  # noqa: E501
             )
             assert response.json()["response"]["numFound"] == 1
             assert response.json()["response"]["docs"][0]["id"] == "10000017"
@@ -420,7 +420,7 @@ class TestSolrSessionLiveService:
             assert response.status_code == 200
             assert (
                 response.url
-                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=id%3A10000001&fl=id%2Ctitle"
+                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=id%3A10000001&fl=id%2Ctitle"  # noqa: E501
             )
             assert response.json() == {
                 "response": {
@@ -441,7 +441,7 @@ class TestSolrSessionLiveService:
             assert response.status_code == 200
             assert (
                 response.url
-                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=id%3A10000017"
+                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=id%3A10000017"  # noqa: E501
             )
             assert response.json()["response"]["numFound"] == 1
             assert response.json()["response"]["docs"][0]["id"] == "10000017"
@@ -454,7 +454,7 @@ class TestSolrSessionLiveService:
             assert response.status_code == 200
             assert (
                 response.url
-                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=ss_marc_tag_001%3Aocn437048096"
+                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=ss_marc_tag_001%3Aocn437048096"  # noqa: E501
             )
             assert response.json()["response"]["docs"][0]["id"] == "11499389"
 
@@ -470,7 +470,7 @@ class TestSolrSessionLiveService:
             assert response.status_code == 200
             assert (
                 response.url
-                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=isbn%3A9780810984912+OR+9781419741890+OR+0810984911&fl=id%2Ctitle%2Cauthor_raw%2CpublishYear%2Ccreated_date%2Cmaterial_type%2Ccall_number%2Cisbn%2Clanguage%2Ceprovider%2Cecontrolnumber%2Ceurl%2Cdigital_avail_type%2Cdigital_copies_owned"
+                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=isbn%3A9780810984912+OR+9781419741890+OR+0810984911&fl=id%2Ctitle%2Cauthor_raw%2CpublishYear%2Ccreated_date%2Cmaterial_type%2Ccall_number%2Cisbn%2Clanguage%2Ceprovider%2Cecontrolnumber%2Ceurl%2Cdigital_avail_type%2Cdigital_copies_owned"  # noqa: E501
             )
 
     def test_search_isbns_empty(self, live_key):
@@ -501,7 +501,7 @@ class TestSolrSessionLiveService:
             assert response.status_code == 200
             assert (
                 response.url
-                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=econtrolnumber%3A8CD53ED9-CEBD-4F78-8BEF-20A58F6F3857&fl=id%2Ctitle%2Cauthor_raw%2CpublishYear%2Ccreated_date%2Cmaterial_type%2Ccall_number%2Cisbn%2Clanguage%2Ceprovider%2Cecontrolnumber%2Ceurl%2Cdigital_avail_type%2Cdigital_copies_owned"
+                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=econtrolnumber%3A8CD53ED9-CEBD-4F78-8BEF-20A58F6F3857&fl=id%2Ctitle%2Cauthor_raw%2CpublishYear%2Ccreated_date%2Cmaterial_type%2Ccall_number%2Cisbn%2Clanguage%2Ceprovider%2Cecontrolnumber%2Ceurl%2Cdigital_avail_type%2Cdigital_copies_owned"  # noqa: E501
             )
 
     def test_search_upcs(self, live_key):
@@ -513,7 +513,7 @@ class TestSolrSessionLiveService:
             assert response.status_code == 200
             assert (
                 response.url
-                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=sm_marc_tag_024_a%3A085391200390&fl=id%2Ctitle%2Cauthor_raw%2CpublishYear%2Ccreated_date%2Cmaterial_type%2Ccall_number%2Cisbn%2Clanguage%2Ceprovider%2Cecontrolnumber%2Ceurl%2Cdigital_avail_type%2Cdigital_copies_owned"
+                == "https://www.bklynlibrary.org/solr/api/select/?rows=10&fq=ss_type%3Acatalog&q=sm_marc_tag_024_a%3A085391200390&fl=id%2Ctitle%2Cauthor_raw%2CpublishYear%2Ccreated_date%2Cmaterial_type%2Ccall_number%2Cisbn%2Clanguage%2Ceprovider%2Cecontrolnumber%2Ceurl%2Cdigital_avail_type%2Cdigital_copies_owned"  # noqa: E501
             )
             assert response.json()["response"]["docs"][0]["id"] == "11499389"
 
@@ -528,5 +528,5 @@ class TestSolrSessionLiveService:
             assert response.status_code == 200
             assert (
                 response.url
-                == f"https://www.bklynlibrary.org/solr/api/select/?rows={arg1}&fq=ss_type%3Acatalog&q=digital_copies_owned%3A0+AND+digital_avail_type%3ANormal&start={arg2}&fl=id%2Ctitle%2Cauthor_raw%2CpublishYear%2Ccreated_date%2Cmaterial_type%2Ccall_number%2Cisbn%2Clanguage%2Ceprovider%2Cecontrolnumber%2Ceurl%2Cdigital_avail_type%2Cdigital_copies_owned"
+                == f"https://www.bklynlibrary.org/solr/api/select/?rows={arg1}&fq=ss_type%3Acatalog&q=digital_copies_owned%3A0+AND+digital_avail_type%3ANormal&start={arg2}&fl=id%2Ctitle%2Cauthor_raw%2CpublishYear%2Ccreated_date%2Cmaterial_type%2Ccall_number%2Cisbn%2Clanguage%2Ceprovider%2Cecontrolnumber%2Ceurl%2Cdigital_avail_type%2Cdigital_copies_owned"  # noqa: E501
             )


### PR DESCRIPTION
In general code in tests does not need to abide by any line length requirements.
This change silences Flake8 warnings about longer lines in `test_sesssion.py` so other important warnings are not overlooked in the crowd.