### PR TITLE
Actions-tests-mod

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,5 +1,8 @@
 name: tests
-on: [push, pull_request]
+on: 
+  push:
+    - main
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,8 +1,11 @@
 name: tests
 on: 
   push:
-    - main
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A change to github actions to trigger tests only on push to main and PR to main.
This also avoids duplication of tests on push & PR previously observed. See [this discussion](https://github.com/orgs/community/discussions/26940) for details.